### PR TITLE
Correctly specify prereqs on MSWin32

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,3 +22,6 @@ repository.type = git
 perl = v5.8.5
 Compress::Zlib = 1.0
 Font::TTF = 0
+
+[OSPrereqs / MSWin32]
+Win32::TieRegistry = 0


### PR DESCRIPTION
On Windows, the Win32::TieRegistry module is used. This module is
not in core.

It's not specified in dist.ini and thus it's not in the Makefile.PL
generated by dzil.
The dist.ini does not have a 'native' way of determining prerequisites
that differ per OS platform, so we need to use the OSPrereqs plugin.