### PR TITLE
Two POD tests in CPAN dist

### DIFF
--- a/t/pod.t
+++ b/t/pod.t
@@ -1,6 +1,0 @@
-use Test::More;
-
-eval 'use Test::Pod 1.00';
-plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
-
-all_pod_files_ok();


### PR DESCRIPTION
dist.ini specifies the (standard) dzil plubin [PodSyntaxTests].
This generates a test for POD using Test::Pod.
But the distribution itself already contains t/pod.t so during
installation, the POD is tested twice.

This pull request gets rid of the t/pod.t in favor of the automatically
generated test.