### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+
+language: perl
+
+perl:
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+  - "5.8"
+
+install:
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+   - dzil test --author --release


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a free continuous integration service for open source projects.  This PR adds an initial version of the configuration file for the Travis service.  Using this configuration `PDF::API2` builds and tests successfully on Perls 5.8 to 5.24.

If you have any questions or comments concerning this PR, please don't hesitate to contact me!  This PR is intended to be helpful, so if it can be improved upon in any way, let me know and I'll resubmit or update as appropriate.