### PR TITLE
Use warnings and strict pragmas in tests

### DIFF
--- a/t/font-ttf.t
+++ b/t/font-ttf.t
@@ -1,5 +1,8 @@
 use Test::More tests => 1;
 
+use warnings;
+use strict;
+
 use PDF::API2;
 
 my @possible_locations = (

--- a/t/font-type1.t
+++ b/t/font-type1.t
@@ -1,5 +1,8 @@
 use Test::More tests => 1;
 
+use warnings;
+use strict;
+
 use PDF::API2;
 
 my $pfb_file = '/usr/share/fonts/type1/gsfonts/a010013l.pfb';


### PR DESCRIPTION
This is then consistent with the usage in the remainder of the test suite as
well as being current Perl best practice.