### PR TITLE
Replace string form eval with block form in tests

### DIFF
--- a/t/gd.t
+++ b/t/gd.t
@@ -6,7 +6,7 @@ use strict;
 use PDF::API2;
 
 SKIP: {
-    eval "require GD";
+    eval { require GD };
     if ($@) {
         skip q{GD not installed; skipping image_gd tests}, 2;
     }


### PR DESCRIPTION
The string form (a.k.a expression form) of eval is recompiled every time it
is used whereas the block form is compiled once.  Also, the block form gives
compile-time warnings, where the string form doesn't.  Hence it's better in
general to use the block form of `eval`.