### PR TITLE
Fix IO-related perlcritic warnings

### DIFF
--- a/lib/PDF/API2/Basic/PDF/Dict.pm
+++ b/lib/PDF/API2/Basic/PDF/Dict.pm
@@ -201,7 +201,7 @@ sub outobjdeep {
 
     }
     elsif (defined $self->{' streamfile'}) {
-        open(DICTFH, $self->{' streamfile'}) || die "Unable to open $self->{' streamfile'}";
+        open(DICTFH, "<", $self->{' streamfile'}) || die "Unable to open $self->{' streamfile'}";
         binmode(DICTFH, ':raw');
 
         $fh->print(" stream\n");

--- a/lib/PDF/API2/Basic/PDF/Dict.pm
+++ b/lib/PDF/API2/Basic/PDF/Dict.pm
@@ -201,13 +201,13 @@ sub outobjdeep {
 
     }
     elsif (defined $self->{' streamfile'}) {
-        open(DICTFH, "<", $self->{' streamfile'}) || die "Unable to open $self->{' streamfile'}";
-        binmode(DICTFH, ':raw');
+        open(my $dictfh, "<", $self->{' streamfile'}) || die "Unable to open $self->{' streamfile'}";
+        binmode($dictfh, ':raw');
 
         $fh->print(" stream\n");
         $loc = $fh->tell();
         my $stream;
-        while (read(DICTFH, $stream, 4096)) {
+        while (read($dictfh, $stream, 4096)) {
             unless ($self->{' nofilt'}) {
                 foreach my $filter (reverse @filters) {
                     $stream = $filter->outfilt($stream, 0);
@@ -215,7 +215,7 @@ sub outobjdeep {
             }
             $fh->print($stream);
         }
-        close DICTFH;
+        close $dictfh;
         unless ($self->{' nofilt'}) {
             $stream = '';
             foreach my $filter (reverse @filters) {
@@ -285,6 +285,7 @@ sub read_stream {
     }
     seek $fh, $self->{' streamloc'}, 0;
     my ($i, $data);
+    my $dictfh;
     for ($i = 0; $i < $len; $i += 4096) {
         unless ($i + 4096 > $len) {
             read $fh, $data, 4096;
@@ -303,22 +304,22 @@ sub read_stream {
         # 2) The length check should be looking at $self->{' stream'}
         #    rather than $data (which just contains the latest chunk)
         if (not $force_memory and not defined $self->{' streamfile'} and ((length($data) * 2) > $mincache)) {
-            open(DICTFH, '>', $tempbase) or next;
-            binmode DICTFH, ':raw';
+            open($dictfh, '>', $tempbase) or next;
+            binmode $dictfh, ':raw';
             $self->{' streamfile'} = $tempbase;
             $tempbase =~ s/-(\d+)$/'-' . ($1 + 1)/oe;        # prepare for next use
-            print DICTFH $self->{' stream'};
+            print $dictfh $self->{' stream'};
             undef $self->{' stream'};
         }
         if (defined $self->{' streamfile'}) {
-            print DICTFH $data;
+            print $dictfh $data;
         }
         else {
             $self->{' stream'} .= $data;
         }
     }
 
-    close DICTFH if defined $self->{' streamfile'};
+    close $dictfh if defined $self->{' streamfile'};
     $self->{' nofilt'} = 0;
     return $self;
 }

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/ACTFile.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/ACTFile.pm
@@ -44,7 +44,7 @@ sub new {
     $csd->{Gamma}=PDFArray(map {PDFNum($_)} (2.22218, 2.22218, 2.22218));
 
     my $fh;
-    open($fh,$file);
+    open($fh, "<", $file);
     binmode($fh,':raw');
     read($fh,$csd->{' stream'},768);
     close($fh);

--- a/lib/PDF/API2/Resource/Font/BdFont.pm
+++ b/lib/PDF/API2/Resource/Font/BdFont.pm
@@ -167,7 +167,7 @@ sub readBDF {
     $data->{wx}={};
 
     if(! -e $file) {die "file='$file' not existant.";}
-    open(AFMF, $file) or die "Can't find the BDF file for $file";
+    open(AFMF, "<", $file) or die "Can't find the BDF file for $file";
     local($/, $_) = ("\n", undef);  # ensure correct $INPUT_RECORD_SEPARATOR
     while ($_=<AFMF>) {
         chomp($_);

--- a/lib/PDF/API2/Resource/Font/BdFont.pm
+++ b/lib/PDF/API2/Resource/Font/BdFont.pm
@@ -167,9 +167,9 @@ sub readBDF {
     $data->{wx}={};
 
     if(! -e $file) {die "file='$file' not existant.";}
-    open(AFMF, "<", $file) or die "Can't find the BDF file for $file";
+    open(my $afmf, "<", $file) or die "Can't find the BDF file for $file";
     local($/, $_) = ("\n", undef);  # ensure correct $INPUT_RECORD_SEPARATOR
-    while ($_=<AFMF>) {
+    while ($_=<$afmf>) {
         chomp($_);
         if (/^STARTCHAR/ .. /^ENDCHAR/) {
             if (/^STARTCHAR\s+(\S+)/) {
@@ -196,7 +196,7 @@ sub readBDF {
                 $data->{uc($1)}.=$2;
         }
     }
-    close(AFMF);
+    close($afmf);
     unless (exists $data->{wx}->{'.notdef'}) {
         $data->{wx}->{'.notdef'} = 0;
         $data->{bbox}{'.notdef'} = [0, 0, 0, 0];

--- a/lib/PDF/API2/Resource/Font/Postscript.pm
+++ b/lib/PDF/API2/Resource/Font/Postscript.pm
@@ -88,7 +88,7 @@ sub readPFAPFB {
 
     $l=-s $file;
 
-    open(INF,$file);
+    open(INF, "<", $file);
     binmode(INF,':raw');
     read(INF,$line,2);
     @lines=unpack('C*',$line);
@@ -165,7 +165,7 @@ sub readAFM
     $data->{lastchar}=0;
 
     if(! -e $file) {die "file='$file' not existant.";}
-    open(AFMF, $file) or die "Can't find the AFM file for $file";
+    open(AFMF, "<", $file) or die "Can't find the AFM file for $file";
     local($/, $_) = ("\n", undef);  # ensure correct $INPUT_RECORD_SEPARATOR
     while ($_=<AFMF>) 
     {
@@ -302,7 +302,7 @@ sub readPFM {
     $data->{char}=[];
 
     my $buf;
-    open($fh,$file) || return undef;
+    open($fh, "<", $file) || return undef;
     binmode($fh,':raw');
     read($fh,$buf,117 + 30);
 

--- a/lib/PDF/API2/Resource/Font/Postscript.pm
+++ b/lib/PDF/API2/Resource/Font/Postscript.pm
@@ -88,41 +88,41 @@ sub readPFAPFB {
 
     $l=-s $file;
 
-    open(INF, "<", $file);
-    binmode(INF,':raw');
-    read(INF,$line,2);
+    open(my $inf, "<", $file);
+    binmode($inf,':raw');
+    read($inf,$line,2);
     @lines=unpack('C*',$line);
     if(($lines[0]==0x80) && ($lines[1]==1)) {
-        read(INF,$line,4);
+        read($inf,$line,4);
         $l1=unpack('V',$line);
-        seek(INF,$l1,1);
-        read(INF,$line,2);
+        seek($inf,$l1,1);
+        read($inf,$line,2);
         @lines=unpack('C*',$line);
         if(($lines[0]==0x80) && ($lines[1]==2)) {
-            read(INF,$line,4);
+            read($inf,$line,4);
             $l2=unpack('V',$line);
         } else {
             die "corrupt pfb in file '$file' at marker='2'.";
         }
-        seek(INF,$l2,1);
-        read(INF,$line,2);
+        seek($inf,$l2,1);
+        read($inf,$line,2);
         @lines=unpack('C*',$line);
         if(($lines[0]==0x80) && ($lines[1]==1)) {
-            read(INF,$line,4);
+            read($inf,$line,4);
             $l3=unpack('V',$line);
         } else {
             die "corrupt pfb in file '$file' at marker='3'.";
         }
-        seek(INF,0,0);
-        @lines=<INF>;
-        close(INF);
+        seek($inf,0,0);
+        @lines=<$inf>;
+        close($inf);
         $stream=join('',@lines);
         $t1stream=substr($stream,6,$l1);
         $t1stream.=substr($stream,12+$l1,$l2);
         $t1stream.=substr($stream,18+$l1+$l2,$l3);
     } elsif($line eq '%!') {
-        seek(INF,0,0);
-        while($line=<INF>) {
+        seek($inf,0,0);
+        while($line=<$inf>) {
             if(!$l1) {
                 $head.=$line;
                 if($line=~/eexec$/){
@@ -165,9 +165,9 @@ sub readAFM
     $data->{lastchar}=0;
 
     if(! -e $file) {die "file='$file' not existant.";}
-    open(AFMF, "<", $file) or die "Can't find the AFM file for $file";
+    open(my $afmf, "<", $file) or die "Can't find the AFM file for $file";
     local($/, $_) = ("\n", undef);  # ensure correct $INPUT_RECORD_SEPARATOR
-    while ($_=<AFMF>) 
+    while ($_=<$afmf>) 
     {
         if (/^StartCharMetrics/ .. /^EndCharMetrics/) 
         {
@@ -237,7 +237,7 @@ sub readAFM
                 ## print STDERR "Can't parse: $_";
         }
     }
-    close(AFMF);
+    close($afmf);
     unless (exists $data->{wx}->{'.notdef'}) 
     {
         $data->{wx}->{'.notdef'} = 0;

--- a/lib/PDF/API2/Resource/XObject/Image/GIF.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/GIF.pm
@@ -121,7 +121,7 @@ sub new {
     $self->{' apipdf'}=$pdf;
 
     my $fh = IO::File->new;
-    open($fh,$file);
+    open($fh, "<", $file);
     binmode($fh,':raw');
     my $buf;
     $fh->read($buf,6); # signature

--- a/lib/PDF/API2/Resource/XObject/Image/JPEG.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/JPEG.pm
@@ -26,7 +26,7 @@ sub new {
         $fh = $file;
     }
     else {
-        open $fh, $file;
+        open $fh, "<", $file;
     }
     binmode $fh, ':raw';
 

--- a/lib/PDF/API2/Resource/XObject/Image/PNG.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNG.pm
@@ -25,11 +25,11 @@ sub new {
     $self->{' apipdf'}=$pdf;
 
     my $fh = IO::File->new;
-    open($fh,$file);
+    open($fh, "<", $file);
     binmode($fh,':raw');
 
     my ($buf,$l,$crc,$w,$h,$bpc,$cs,$cm,$fm,$im,$palete,$trns);
-    open($fh,$file);
+    open($fh, "<", $file);
     binmode($fh);
     seek($fh,8,0);
     $self->{' stream'}='';

--- a/lib/PDF/API2/Resource/XObject/Image/PNM.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNM.pm
@@ -122,16 +122,16 @@ sub read_pnm {
 
     my ($buf,$t,$s,$line);
     my ($w,$h,$bpc,$cs,$img,@img)=(0,0,'','','');
-    open(INF, "<", $file);
-    binmode(INF,':raw');
-    my $info=readppmheader(INF);
+    open(my $inf, "<", $file);
+    binmode($inf,':raw');
+    my $info=readppmheader($inf);
     if($info->{type} == 4) {
         $bpc=1;
-        read(INF,$self->{' stream'},($info->{width}*$info->{height}/8));
+        read($inf,$self->{' stream'},($info->{width}*$info->{height}/8));
         $cs='DeviceGray';
         $self->{Decode}=PDFArray(PDFNum(1),PDFNum(0));
     } elsif($info->{type} == 5) {
-        $buf.=<INF>;
+        $buf.=<$inf>;
         if($info->{max}==255){
             $s=0;
         } else {
@@ -140,11 +140,11 @@ sub read_pnm {
         $bpc=8;
         if($s>0) {
             for($line=($info->{width}*$info->{height});$line>0;$line--) {
-                read(INF,$buf,1);
+                read($inf,$buf,1);
                 $self->{' stream'}.=pack('C',(unpack('C',$buf)*$s));
             }
         } else {
-            read(INF,$self->{' stream'},$info->{width}*$info->{height});
+            read($inf,$self->{' stream'},$info->{width}*$info->{height});
         }
         $cs='DeviceGray';
     } elsif($info->{type} == 6) {
@@ -156,19 +156,19 @@ sub read_pnm {
         $bpc=8;
         if($s>0) {
             for($line=($info->{width}*$info->{height});$line>0;$line--) {
-                read(INF,$buf,1);
+                read($inf,$buf,1);
                 $self->{' stream'}.=pack('C',(unpack('C',$buf)*$s));
-                read(INF,$buf,1);
+                read($inf,$buf,1);
                 $self->{' stream'}.=pack('C',(unpack('C',$buf)*$s));
-                read(INF,$buf,1);
+                read($inf,$buf,1);
                 $self->{' stream'}.=pack('C',(unpack('C',$buf)*$s));
             }
         } else {
-            read(INF,$self->{' stream'},$info->{width}*$info->{height}*3);
+            read($inf,$self->{' stream'},$info->{width}*$info->{height}*3);
         }
         $cs='DeviceRGB';
     }
-    close(INF);
+    close($inf);
 
     $self->width($info->{width});
     $self->height($info->{height});

--- a/lib/PDF/API2/Resource/XObject/Image/PNM.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNM.pm
@@ -122,7 +122,7 @@ sub read_pnm {
 
     my ($buf,$t,$s,$line);
     my ($w,$h,$bpc,$cs,$img,@img)=(0,0,'','','');
-    open(INF,$file);
+    open(INF, "<", $file);
     binmode(INF,':raw');
     my $info=readppmheader(INF);
     if($info->{type} == 4) {

--- a/lib/PDF/API2/Resource/XObject/Image/TIFF.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/TIFF.pm
@@ -356,7 +356,7 @@ sub new {
     seek($self->{fh},0,0);
   } else {
     $self->{fh} = IO::File->new;
-    open($self->{fh},"< $file");
+    open($self->{fh}, "<", $file);
   }
   binmode($self->{fh},':raw');
   my $fh = $self->{fh};


### PR DESCRIPTION
This PR updates the code to use the three argument form of `open` and replaces bareword filehandles with scoped lexical variables.  These issues were found by `perlcritic` running at the default severity level.  The reason why both issues are handled in the one PR is that the changes often affect the same lines of code, hence if put into separate PRs they would cause conflicts.

This PR is submitted in the hope that it is helpful.  If it can be improved upon or needs to be updated, please just let me know and I'll update as required and resubmit.

I noticed a potential issue in `lib/PDF/API2/Resource/Font/Postscript.pm` at line 118 while preparing this PR: the filehandle is closed on this line, however it is also used in the following `elsif` block.  Unfortunately, I'm not that familiar with the code, so I'm not 100% sure what the correct code would be, however it looks like it would be best to close the filehandle outside the `if`-`elsif`-`else` blocks so that seeks and reads being called in the `elsif` block run on an opened filehandle.  Just thought you'd like to know!