### PR TITLE
Add explicit LICENSE section to main source POD

### DIFF
--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -2318,4 +2318,20 @@ PDF::API2 was originally written by Alfred Reibenschuh.
 
 It is currently being maintained by Steve Simms.
 
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 =cut


### PR DESCRIPTION
This fixes the `has_license_in_source_file` core kwalitee issue on
[CPANTS](http://cpants.cpanauthors.org/release/SSIMMS/PDF-API2-2.028).

I chose only to add the LGPL version 2.1 as that is what is mentioned in `dist.ini`.  Some files in the dist mention the use of the Artistic License, however that seems to be specific to those files, hence the Artistic License hasn't been mentioned in the new LICENSE section.

This PR is intended to be helpful.  If it needs to be updated in any way, please just let me know and I'll update it appropriately and resubmit.
