### PR TITLE
Add missing prereq to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,3 +22,4 @@ repository.type = git
 perl = v5.8.5
 Compress::Zlib = 1.0
 Font::TTF = 0
+Win32::TieRegistry = 0


### PR DESCRIPTION
The module `Win32::TieRegistry` was found by
[CPANTS](http://cpants.cpanauthors.org/release/SSIMMS/PDF-API2-2.028) to be
missing from the list of prerequisites for the module, although it is used.
Adding the prereq fixes the `prereq_matches_use` core kwalitee issue (as
tested via `Test::Kwalitee::Extra`).

This PR is intended to be helpful.  If it needs to be changed in any way, please just let me know and I'll update it and resubmit.