### PR TITLE
Generate META.json when building dist

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,7 @@ license = LGPL_2_1
 copyright_holder = Steve Simms
 
 [@Basic]
+[MetaJSON]
 
 [NextRelease]
 format = %-9v %{yyyy-MM-dd}d


### PR DESCRIPTION
The META.json file is meant to replace the old-style META.yml file.  Adding
the MetaJSON `Dist::Zilla` plugin allows this file to be automatically
generated when the distribution is built.

This PR is intended to be helpful.  If it can be improved upon, please simply let me know and I'll update and resubmit it.