### PR TITLE
Add warnings pragma to all files missing it

### DIFF
--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -21,6 +21,7 @@ use PDF::API2::Resource::Shading;
 
 use PDF::API2::NamedDestination;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our @FontDirs = ( (map { "$_/PDF/API2/fonts" } @INC),

--- a/lib/PDF/API2/Annotation.pm
+++ b/lib/PDF/API2/Annotation.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Basic/PDF/Array.pm
+++ b/lib/PDF/API2/Basic/PDF/Array.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Array;
 use base 'PDF::API2::Basic::PDF::Objind';
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/PDF/API2/Basic/PDF/Bool.pm
+++ b/lib/PDF/API2/Basic/PDF/Bool.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Bool;
 use base 'PDF::API2::Basic::PDF::String';
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/PDF/API2/Basic/PDF/Dict.pm
+++ b/lib/PDF/API2/Basic/PDF/Dict.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Dict;
 use base 'PDF::API2::Basic::PDF::Objind';
 
 use strict;
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $mincache;

--- a/lib/PDF/API2/Basic/PDF/File.pm
+++ b/lib/PDF/API2/Basic/PDF/File.pm
@@ -140,6 +140,7 @@ is in PDF which contains the location of the previous cross-reference table.
 
 use strict;
 no strict "refs";
+use warnings;
 
 use Scalar::Util qw(blessed);
 

--- a/lib/PDF/API2/Basic/PDF/Filter/FlateDecode.pm
+++ b/lib/PDF/API2/Basic/PDF/Filter/FlateDecode.pm
@@ -5,6 +5,7 @@ package PDF::API2::Basic::PDF::Filter::FlateDecode;
 use base 'PDF::API2::Basic::PDF::Filter';
 
 use strict;
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 use POSIX qw(ceil floor);

--- a/lib/PDF/API2/Basic/PDF/Filter/LZWDecode.pm
+++ b/lib/PDF/API2/Basic/PDF/Filter/LZWDecode.pm
@@ -4,6 +4,7 @@ package PDF::API2::Basic::PDF::Filter::LZWDecode;
 
 use base 'PDF::API2::Basic::PDF::Filter::FlateDecode';
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Basic/PDF/Literal.pm
+++ b/lib/PDF/API2/Basic/PDF/Literal.pm
@@ -11,6 +11,7 @@ use PDF::API2::Basic::PDF::Filter;
 use PDF::API2::Basic::PDF::Name;
 use Scalar::Util qw(blessed);
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new

--- a/lib/PDF/API2/Basic/PDF/Name.pm
+++ b/lib/PDF/API2/Basic/PDF/Name.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Name;
 use base 'PDF::API2::Basic::PDF::String';
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/PDF/API2/Basic/PDF/Null.pm
+++ b/lib/PDF/API2/Basic/PDF/Null.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Null;
 use base 'PDF::API2::Basic::PDF::Objind';
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/PDF/API2/Basic/PDF/Number.pm
+++ b/lib/PDF/API2/Basic/PDF/Number.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Number;
 use base 'PDF::API2::Basic::PDF::String';
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/PDF/API2/Basic/PDF/Page.pm
+++ b/lib/PDF/API2/Basic/PDF/Page.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Page;
 use base 'PDF::API2::Basic::PDF::Pages';
 
 use strict;
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 use PDF::API2::Basic::PDF::Dict;

--- a/lib/PDF/API2/Basic/PDF/Pages.pm
+++ b/lib/PDF/API2/Basic/PDF/Pages.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::Pages;
 use base 'PDF::API2::Basic::PDF::Dict';
 
 use strict;
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 use PDF::API2::Basic::PDF::Array;

--- a/lib/PDF/API2/Basic/PDF/String.pm
+++ b/lib/PDF/API2/Basic/PDF/String.pm
@@ -17,6 +17,7 @@ package PDF::API2::Basic::PDF::String;
 use base 'PDF::API2::Basic::PDF::Objind';
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/PDF/API2/Basic/PDF/Utils.pm
+++ b/lib/PDF/API2/Basic/PDF/Utils.pm
@@ -27,6 +27,7 @@ A set of utility functions to save the fingers of the PDF library users!
 =cut
 
 use strict;
+use warnings;
 
 use PDF::API2::Basic::PDF::Array;
 use PDF::API2::Basic::PDF::Bool;

--- a/lib/PDF/API2/Content.pm
+++ b/lib/PDF/API2/Content.pm
@@ -13,6 +13,7 @@ use PDF::API2::Matrix;
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw( deprecated recursion uninitialized );
 
 =head1 NAME

--- a/lib/PDF/API2/Lite.pm
+++ b/lib/PDF/API2/Lite.pm
@@ -15,6 +15,7 @@ BEGIN {
 
 }
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME 

--- a/lib/PDF/API2/Matrix.pm
+++ b/lib/PDF/API2/Matrix.pm
@@ -12,10 +12,13 @@ package PDF::API2::Matrix;
 
 # VERSION
 
+use warnings;
+
 sub new {
     my $type = shift;
     my $self = [];
     my $len = scalar(@{$_[0]});
+    my $moo;
     for (@_) {
         return undef if scalar(@{$_}) != $len;
         push(@{$self}, [@{$_}]);

--- a/lib/PDF/API2/NamedDestination.pm
+++ b/lib/PDF/API2/NamedDestination.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Outline.pm
+++ b/lib/PDF/API2/Outline.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Basic::PDF::Dict';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Page.pm
+++ b/lib/PDF/API2/Page.pm
@@ -13,6 +13,7 @@ use PDF::API2::Content::Text;
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/BaseFont.pm
+++ b/lib/PDF/API2/Resource/BaseFont.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/CIDFont.pm
+++ b/lib/PDF/API2/Resource/CIDFont.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/CIDFont/CJKFont.pm
+++ b/lib/PDF/API2/Resource/CIDFont/CJKFont.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::CIDFont';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $fonts = {};

--- a/lib/PDF/API2/Resource/CIDFont/TrueType.pm
+++ b/lib/PDF/API2/Resource/CIDFont/TrueType.pm
@@ -8,6 +8,7 @@ use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Resource::CIDFont::TrueType::FontFile;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm
+++ b/lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm
@@ -11,6 +11,7 @@ use POSIX qw(ceil floor);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ recursion uninitialized ];
 
 our $cmap = {};

--- a/lib/PDF/API2/Resource/ColorSpace.pm
+++ b/lib/PDF/API2/Resource/ColorSpace.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Basic::PDF::Array';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/ColorSpace/DeviceN.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/DeviceN.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/ACTFile.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/ACTFile.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace::Indexed';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/Hue.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/Hue.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace::Indexed';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/WebColor.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/WebColor.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace::Indexed';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/ColorSpace/Separation.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Separation.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/ExtGState.pm
+++ b/lib/PDF/API2/Resource/ExtGState.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/Font.pm
+++ b/lib/PDF/API2/Resource/Font.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub encodeByData {

--- a/lib/PDF/API2/Resource/Font/BdFont.pm
+++ b/lib/PDF/API2/Resource/Font/BdFont.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::Font';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $BmpNum = 0;

--- a/lib/PDF/API2/Resource/Font/CoreFont.pm
+++ b/lib/PDF/API2/Resource/Font/CoreFont.pm
@@ -9,6 +9,7 @@ use File::Basename;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $fonts;

--- a/lib/PDF/API2/Resource/Font/Postscript.pm
+++ b/lib/PDF/API2/Resource/Font/Postscript.pm
@@ -10,6 +10,7 @@ use IO::File qw();
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/Font/SynFont.pm
+++ b/lib/PDF/API2/Resource/Font/SynFont.pm
@@ -10,6 +10,7 @@ use Unicode::UCD 'charinfo';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/UniFont.pm
+++ b/lib/PDF/API2/Resource/UniFont.pm
@@ -4,6 +4,7 @@ package PDF::API2::Resource::UniFont;
 
 use Encode qw(:all);
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/XObject/Image/GD.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/GD.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::XObject::Image';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/XObject/Image/GIF.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/GIF.pm
@@ -8,6 +8,7 @@ use IO::File;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 # added from PDF::Create:

--- a/lib/PDF/API2/Resource/XObject/Image/PNG.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNG.pm
@@ -11,6 +11,7 @@ use IO::File;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/XObject/Image/PNM.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNM.pm
@@ -12,6 +12,7 @@ use IO::File;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/XObject/Image/TIFF.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/TIFF.pm
@@ -9,6 +9,7 @@ use Compress::Zlib;
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/UniWrap.pm
+++ b/lib/PDF/API2/UniWrap.pm
@@ -18,6 +18,7 @@ BEGIN {
 
 }
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $DEBUG = 0;

--- a/lib/PDF/API2/Util.pm
+++ b/lib/PDF/API2/Util.pm
@@ -2,6 +2,7 @@ package PDF::API2::Util;
 
 # VERSION
 
+use warnings;
 no warnings qw[ recursion uninitialized ];
 
 BEGIN {

--- a/lib/PDF/API2/Win32.pm
+++ b/lib/PDF/API2/Win32.pm
@@ -2,6 +2,7 @@ package PDF::API2::Win32;
 
 # VERSION
 
+use warnings;
 no warnings qw[ deprecated recursion uninitialized ];
 
 


### PR DESCRIPTION
Using the warnings pragma is considered best practice.  By adding the
warnings pragma to all files did not cause new warnings to appear in the
test output.  This change fixes the `use_warnings` kwalitee test on
[CPANTS](http://cpants.cpanauthors.org/release/SSIMMS/PDF-API2-2.028).

This PR is submitted in the hope that it is helpful.  If it can be improved upon in any way, please simply let me know and I'll update and resubmit it.
