### PR TITLE
Use strict pragma wherever possible

### DIFF
--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -21,6 +21,8 @@ use PDF::API2::Resource::Shading;
 
 use PDF::API2::NamedDestination;
 
+use strict;
+no strict 'vars';
 no warnings qw[ deprecated recursion uninitialized ];
 
 our @FontDirs = ( (map { "$_/PDF/API2/fonts" } @INC),

--- a/lib/PDF/API2/Annotation.pm
+++ b/lib/PDF/API2/Annotation.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Basic/PDF/Filter/LZWDecode.pm
+++ b/lib/PDF/API2/Basic/PDF/Filter/LZWDecode.pm
@@ -4,6 +4,7 @@ package PDF::API2::Basic::PDF::Filter::LZWDecode;
 
 use base 'PDF::API2::Basic::PDF::Filter::FlateDecode';
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Content.pm
+++ b/lib/PDF/API2/Content.pm
@@ -13,6 +13,7 @@ use PDF::API2::Matrix;
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw( deprecated recursion uninitialized );
 
 =head1 NAME

--- a/lib/PDF/API2/Lite.pm
+++ b/lib/PDF/API2/Lite.pm
@@ -15,6 +15,7 @@ BEGIN {
 
 }
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME 

--- a/lib/PDF/API2/Matrix.pm
+++ b/lib/PDF/API2/Matrix.pm
@@ -12,6 +12,8 @@ package PDF::API2::Matrix;
 
 # VERSION
 
+use strict;
+
 sub new {
     my $type = shift;
     my $self = [];

--- a/lib/PDF/API2/NamedDestination.pm
+++ b/lib/PDF/API2/NamedDestination.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Outline.pm
+++ b/lib/PDF/API2/Outline.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Basic::PDF::Dict';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Page.pm
+++ b/lib/PDF/API2/Page.pm
@@ -13,6 +13,7 @@ use PDF::API2::Content::Text;
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/BaseFont.pm
+++ b/lib/PDF/API2/Resource/BaseFont.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/CIDFont.pm
+++ b/lib/PDF/API2/Resource/CIDFont.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME
@@ -67,7 +68,7 @@ sub new_api
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     $api->{pdf}->out_obj($api->{pages});
     return($obj);

--- a/lib/PDF/API2/Resource/CIDFont/CJKFont.pm
+++ b/lib/PDF/API2/Resource/CIDFont/CJKFont.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::CIDFont';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $fonts = {};
@@ -49,7 +50,7 @@ sub _look_for_font {
     return({%{$fonts->{$fname}}}) if(defined $fonts->{$fname});
 
     if(defined $subs->{$fname}) {
-        $data=_look_for_font($subs->{$fname}->{-alias});
+        my $data=_look_for_font($subs->{$fname}->{-alias});
         foreach my $k (keys %{$subs->{$fname}}) {
           next if($k=~/^\-/);
           if(substr($k,0,1) eq '+')
@@ -162,7 +163,7 @@ sub new_api {
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     $api->{pdf}->out_obj($api->{pages});
     return($obj);

--- a/lib/PDF/API2/Resource/CIDFont/TrueType.pm
+++ b/lib/PDF/API2/Resource/CIDFont/TrueType.pm
@@ -8,6 +8,7 @@ use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Resource::CIDFont::TrueType::FontFile;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME
@@ -93,7 +94,7 @@ sub new_api
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     $api->{pdf}->out_obj($api->{pages});
     return($obj);

--- a/lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm
+++ b/lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm
@@ -11,6 +11,7 @@ use POSIX qw(ceil floor);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ recursion uninitialized ];
 
 our $cmap = {};
@@ -236,11 +237,11 @@ sub readcffdict
         }
         elsif($b0==30) # float
         {
-            $e=1;
+            my $e=1;
             while($e)
             {
                 read($fh,$buf,1);
-                $v0=unpack('C',$buf);
+                my $v0=unpack('C',$buf);
                 foreach my $m ($v0>>8,$v0&0xf)
                 {
                     if($m<10)
@@ -356,6 +357,7 @@ sub readcffstructs
     my $data={};
     # read CFF table
     seek($fh,$font->{'CFF '}->{' OFFSET'},0);
+    my $buf;
     read($fh,$buf, 4);
     my ($cffmajor,$cffminor,$cffheadsize,$cffglobaloffsize)=unpack('C4',$buf);
 
@@ -426,7 +428,7 @@ sub new {
     $data->{obj}=$font;
 
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new();
+    my $self=$class->SUPER::new();
 
     $self->{Filter}=PDFArray(PDFName('FlateDecode'));
     $self->{' font'}=$font;

--- a/lib/PDF/API2/Resource/ColorSpace.pm
+++ b/lib/PDF/API2/Resource/ColorSpace.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Basic::PDF::Array';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME
@@ -27,7 +28,7 @@ sub new {
     my ($class,$pdf,$key,%opts)=@_;
 
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new();
+    my $self=$class->SUPER::new();
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->name($key || pdfkey());
     $self->{' apipdf'}=$pdf;
@@ -46,7 +47,7 @@ sub new_api {
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     return($obj);
 }

--- a/lib/PDF/API2/Resource/ColorSpace/DeviceN.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/DeviceN.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {
@@ -16,7 +17,7 @@ sub new {
     $sampled=2;
     
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new($pdf,$key);
+    my $self=$class->SUPER::new($pdf,$key);
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->{' apipdf'}=$pdf;
 
@@ -79,7 +80,7 @@ sub new_api {
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},pdfkey(),@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     return($obj);
 }

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed.pm
@@ -7,13 +7,14 @@ use base 'PDF::API2::Resource::ColorSpace';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {
     my ($class,$pdf,$key,%opts)=@_;
 
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new($pdf,$key,%opts);
+    my $self=$class->SUPER::new($pdf,$key,%opts);
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->{' apipdf'}=$pdf;
 

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/ACTFile.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/ACTFile.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace::Indexed';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME
@@ -32,7 +33,7 @@ sub new {
     my ($class,$pdf,$file)=@_;
     die "could not find act-file '$file'." unless(-f $file);
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new($pdf,pdfkey());
+    my $self=$class->SUPER::new($pdf,pdfkey());
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->{' apipdf'}=$pdf;
     my $csd=PDFDict();

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/Hue.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/Hue.pm
@@ -7,13 +7,14 @@ use base 'PDF::API2::Resource::ColorSpace::Indexed';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {
     my ($class,$pdf)=@_;
 
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new($pdf,pdfkey());
+    my $self=$class->SUPER::new($pdf,pdfkey());
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->{' apipdf'}=$pdf;
     my $csd=PDFDict();

--- a/lib/PDF/API2/Resource/ColorSpace/Indexed/WebColor.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Indexed/WebColor.pm
@@ -7,13 +7,14 @@ use base 'PDF::API2::Resource::ColorSpace::Indexed';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {
     my ($class,$pdf)=@_;
 
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new($pdf,pdfkey());
+    my $self=$class->SUPER::new($pdf,pdfkey());
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->{' apipdf'}=$pdf;
     my $csd=PDFDict();

--- a/lib/PDF/API2/Resource/ColorSpace/Separation.pm
+++ b/lib/PDF/API2/Resource/ColorSpace/Separation.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::ColorSpace';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME
@@ -28,7 +29,7 @@ sub new {
     my ($name,@clr)=@opts;
     
     $class = ref $class if ref $class;
-    $self=$class->SUPER::new($pdf,$key,@opts);
+    my $self=$class->SUPER::new($pdf,$key,@opts);
     $pdf->new_obj($self) unless($self->is_obj($pdf));
     $self->{' apipdf'}=$pdf;
 
@@ -116,7 +117,7 @@ sub new_api {
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},pdfkey(),@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     return($obj);
 }

--- a/lib/PDF/API2/Resource/ExtGState.pm
+++ b/lib/PDF/API2/Resource/ExtGState.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource';
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME
@@ -41,7 +42,7 @@ sub new_api {
     my ($class,$api,@opts)=@_;
 
     my $obj=$class->new($api->{pdf},@opts);
-    $self->{' api'}=$api;
+    my $self->{' api'}=$api;
 
     return($obj);
 }

--- a/lib/PDF/API2/Resource/Font.pm
+++ b/lib/PDF/API2/Resource/Font.pm
@@ -9,6 +9,7 @@ use Encode qw(:all);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub encodeByData {
@@ -155,7 +156,7 @@ sub automap {
 
     my @fnts=();
     my $count=0;
-    while(@glyphs=splice(@nm,0,223)) 
+    while(my @glyphs=splice(@nm,0,223)) 
     {
         my $obj=$self->SUPER::new($self->{' apipdf'},$self->name.'am'.$count);
         $obj->{' data'}={ %{$data} };

--- a/lib/PDF/API2/Resource/Font/BdFont.pm
+++ b/lib/PDF/API2/Resource/Font/BdFont.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::Font';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $BmpNum = 0;

--- a/lib/PDF/API2/Resource/Font/CoreFont.pm
+++ b/lib/PDF/API2/Resource/Font/CoreFont.pm
@@ -9,6 +9,7 @@ use File::Basename;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 our $fonts;

--- a/lib/PDF/API2/Resource/Font/Postscript.pm
+++ b/lib/PDF/API2/Resource/Font/Postscript.pm
@@ -10,6 +10,7 @@ use IO::File qw();
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {
@@ -86,7 +87,7 @@ sub readPFAPFB {
 
     die "cannot find font '$file' ..." unless(-f $file);
 
-    $l=-s $file;
+    my $l=-s $file;
 
     open(INF,$file);
     binmode(INF,':raw');

--- a/lib/PDF/API2/Resource/Font/SynFont.pm
+++ b/lib/PDF/API2/Resource/Font/SynFont.pm
@@ -10,6 +10,7 @@ use Unicode::UCD 'charinfo';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/UniFont.pm
+++ b/lib/PDF/API2/Resource/UniFont.pm
@@ -4,6 +4,7 @@ package PDF::API2::Resource::UniFont;
 
 use Encode qw(:all);
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Resource/XObject/Image/GD.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/GD.pm
@@ -7,6 +7,7 @@ use base 'PDF::API2::Resource::XObject::Image';
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/XObject/Image/GIF.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/GIF.pm
@@ -8,6 +8,7 @@ use IO::File;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 # added from PDF::Create:

--- a/lib/PDF/API2/Resource/XObject/Image/PNG.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNG.pm
@@ -11,6 +11,7 @@ use IO::File;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/XObject/Image/PNM.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/PNM.pm
@@ -12,6 +12,8 @@ use IO::File;
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
 
+use strict;
+no strict 'subs';
 no warnings qw[ deprecated recursion uninitialized ];
 
 sub new {

--- a/lib/PDF/API2/Resource/XObject/Image/TIFF.pm
+++ b/lib/PDF/API2/Resource/XObject/Image/TIFF.pm
@@ -9,6 +9,7 @@ use Compress::Zlib;
 use PDF::API2::Basic::PDF::Utils;
 use PDF::API2::Util;
 
+use strict;
 no warnings qw[ deprecated recursion uninitialized ];
 
 =head1 NAME

--- a/lib/PDF/API2/Util.pm
+++ b/lib/PDF/API2/Util.pm
@@ -2,6 +2,7 @@ package PDF::API2::Util;
 
 # VERSION
 
+use strict;
 no warnings qw[ recursion uninitialized ];
 
 BEGIN {

--- a/lib/PDF/API2/Win32.pm
+++ b/lib/PDF/API2/Win32.pm
@@ -9,6 +9,7 @@ package PDF::API2;
 
 use Win32::TieRegistry;
 
+use strict;
 no warnings qw[ recursion uninitialized ];
 
 our $wf = {};


### PR DESCRIPTION
... where every module in the distribution now uses the `strict` pragma.
Only in `PDF::API2` was it necessary to turn off strict for `'vars'`.  The
reason being the options passed around are sometimes handles as arrays and
other times as hashes and it would require lots of digging to sort that
particular issue out.  Nevertheless, it was possible to add `strict` to all
modules where this was missing and to make any variables lexical which
weren't already so.  In many cases the `new_api` method needed to have the
`$self` variable made lexical and this happened so often, and with the same
structure that it looked like this was a copy-paste issue.  Nevertheless,
this variable is now lexical inside `new_api` throughout the code.  The
tests all pass and the `Test::Kwalitee::Extra` tests no longer complain that
`use strict` isn't used throughout the distribution.  This change should
thus fix the `use_strict`
[CPANTS](http://cpants.cpanauthors.org/release/SSIMMS/PDF-API2-2.028)
violation and allows the distribution to use current Perl best practice.

This PR is submitted in the hope that it is helpful.  If it can be improved in any way, please just let me know and I'll update it appropriately and resubmit.