### PR TITLE
Fix ambiguous call to "open"

### DIFF
--- a/lib/PDF/API2/Basic/PDF/File.pm
+++ b/lib/PDF/API2/Basic/PDF/File.pm
@@ -723,7 +723,7 @@ sub read_objnum {
             $pairs = substr($object_stream->{' stream'}, 0, $object_stream->{'First'}->val);
         }
         else {
-            open $fh, '<', $object_stream->{' streamfile'};
+            CORE::open $fh, '<', $object_stream->{' streamfile'};
             read($fh, $pairs, $object_stream->{'First'}->val());
         }
         my @map = split /\s+/, $pairs;


### PR DESCRIPTION
This module exports method "open" and also uses CORE::open to open the file handle. This results in warnings of:

Ambiguous call resolved as CORE::open(), qualify as such or use & at /usr/local/share/perl/5.18.2/PDF/API2/Basic/PDF/File.pm line 726.

Explicitly qualify the open to suppress this warning