### PR TITLE
More forgiving header parser

### DIFF
--- a/lib/PDF/API2/Basic/PDF/File.pm
+++ b/lib/PDF/API2/Basic/PDF/File.pm
@@ -241,7 +241,7 @@ sub open {
     binmode $fh, ':raw';
     $fh->seek(0, 0);            # go to start of file
     $fh->read($buffer, 255);
-    unless ($buffer =~ m/^\%PDF\-1\.(\d)+\s*$cr/mo) {
+    unless ($buffer =~ m/^\%PDF\-1\.(\d)+.*$cr/mo) {
         die "$filename not a PDF file version 1.x";
     }
     $self->{' version'} = $1;


### PR DESCRIPTION
When trying to open PDFs from Sharp scanners, `open` fails reporting invalid PDF version. The header is as follows:
```
%PDF-1.4 Sharp Scanned ImagePDF
%Sharp Non-Encryption
3 0 obj
```
From the PDF spec there are no restrictions stating that after the minor version there should be a newline or similar. Adjusted the code to not care what there is after the 1.x