### PR TITLE
Fix an issue with find_prop

### DIFF
--- a/lib/PDF/API2/Basic/PDF/Pages.pm
+++ b/lib/PDF/API2/Basic/PDF/Pages.pm
@@ -268,7 +268,9 @@ sub find_prop {
         }
     }
     elsif (defined $self->{'Parent'}) {
-        return $self->{'Parent'}->find_prop($prop);
+        if( $self->{'Parent'}->can('find_prop') ){
+            return $self->{'Parent'}->find_prop($prop);
+        }
     }
 
     return;

--- a/t/crude_objind_fix.t
+++ b/t/crude_objind_fix.t
@@ -1,0 +1,18 @@
+use Test::More tests => 2;
+
+use warnings;
+use strict;
+
+use PDF::API2;
+
+my $pdf = PDF::API2::Basic::PDF::File->new;
+
+# I don't know enough to make a good example, but this reproduces the issue
+# I've had in a real PDF:
+
+my $page = PDF::API2::Basic::PDF::Pages->new($pdf,  PDF::API2::Basic::PDF::Objind->new);
+$page->{Parent} = PDF::API2::Basic::PDF::Objind->new;
+my $rv;
+eval{$rv = $page->find_prop("something")};
+ok( ! $@, 'Did not explode') or diag($@);
+ok( ! $rv, 'Did opt get anything back');


### PR DESCRIPTION
I found an issue with a PDF where during ->openpage I got an exception when within  "lib/PDF/API2/Basic/PDF/Pages.pm" it was trying to call "find_prop" on it's ->{Parent} where that was a PDF::API2::Basic::PDF::Objind. 

I patched it and it seemed to work for me, so I thought i'd try and push it upstream.

My test is a bit rubbish, but it does reproduce the issue and since the data of the PDF isn't mine it's the best I can do.