### PR TITLE
Eliminate warnings about depricated assignment to @_

### DIFF
--- a/lib/PDF/API2/Content.pm
+++ b/lib/PDF/API2/Content.pm
@@ -1866,7 +1866,7 @@ sub advancewidth {
 sub text_justified {
     my ($self,$text,$width,%opts) = @_;
     my $initial_width = $self->advancewidth($text);
-    my $space_count = scalar split /\s/, $text;
+    my $space_count = () = split /\s/, $text, -1;
     my $ws = $self->wordspace();
     $self->wordspace(($width - $initial_width) / $space_count) if $space_count > 0;
     $self->text($text,%opts);
@@ -1922,7 +1922,7 @@ sub text_fill_justified {
     my ($line,$ret)=$self->_text_fill_line($text,$width,$over);
     my $ws=$self->wordspace();
     my $w=$self->advancewidth($line);
-    my $space_count = scalar split /\s/, $line;
+    my $space_count = () = split /\s/, $line, -1;
     if (($ret||$w>=$width) and $space_count) {
         $self->wordspace(($width - $w) / $space_count);
     }


### PR DESCRIPTION
When used with warnings on, these two lines will emit these warnings:

Use of implicit split to @_ is deprecated at /usr/local/share/perl5/PDF/API2/Content.pm line 1869
Use of implicit split to @_ is deprecated at /usr/local/share/perl5/PDF/API2/Content.pm line 1925

Assigning the split to anonymous lists solves this problem. Adding the -1 third arg ensure split captures everything - not just the first match.