### PR TITLE
To fix the openning and import of some pdf file

### DIFF
--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -906,7 +906,7 @@ sub proc_pages {
     $pdf->{' apipagecount'} ||= 0;
     foreach my $page ($object->{'Kids'}->elements()) {
         $page->realise();
-        if ($page->{'Type'}->val() eq 'Pages') {
+        if (defined $page->{'Type'} && $page->{'Type'}->val() eq 'Pages') {
             push @pages, proc_pages($pdf, $page);
         }
         else {

--- a/lib/PDF/API2/Basic/PDF/Dict.pm
+++ b/lib/PDF/API2/Basic/PDF/Dict.pm
@@ -82,6 +82,30 @@ sub type {
     return $self->{'Type'}->val();
 }
 
+=head2 $p->find_prop($key)
+
+Searches up through the inheritance tree to find a property.
+
+=cut
+
+sub find_prop {
+    my ($self, $prop) = @_;
+
+    if (defined $self->{$prop}) {
+        if (ref($self->{$prop}) and $self->{$prop}->isa('PDF::API2::Basic::PDF::Objind')) {
+            return $self->{$prop}->realise();
+        }
+        else {
+            return $self->{$prop};
+        }
+    }
+    elsif (defined $self->{'Parent'}) {
+        return $self->{'Parent'}->find_prop($prop);
+    }
+
+    return;
+}
+
 =head2 @filters = $d->filter(@filters)
 
 Get/Set one or more filters being used by the optional stream attached to the dictionary.


### PR DESCRIPTION
I have a bunch of PDF file that only contain a drawing in a mediabox in a one file. Those PDF are generated with SpaceClaim and Catia. Other PDF software open them, but not pdfapi2.

 Trying to open them first produce this error:
Can't call method "val" on an undefined value at /usr/share/perl5/PDF/API2.pm line 909.
Thus adding the defined in API2.pm

Them the problem move to:
Can't locate object method "find_prop" via package "PDF::API2::Basic::PDF::Dict" at /usr/share/perl5/PDF/API2/Basic/PDF/Pages.pm line 272.

So I add an exact copy of find_prop of Pages.pm to Dict.pm
And it solve my problem.

File look like:
%PDF-1.4
%<95><95><95>æ
1 0 obj <</CreationDate(D:20171218132646-05'00') /Creator(SpaceClaim) /Producer(SpaceClaim)>> endobj
2 0 obj <</Pages 3 0 R>> endobj
3 0 obj <</Count 1 /Kids[4 0 R]>> endobj
4 0 obj
<</MediaBox[0 0 1224 792] /Parent 3 0 R /Contents 5 0 R /Group <</CS/DeviceRGB /S/Transparency /I false /K false>> /Resources <</ProcSet [/PDF/Text/ImageB/ImageC/ImageI] /ExtGState <</GS0 6 0 R /GS1 7 0 R>> /XObject <</I0 9 0 R>>>>>>
endobj
5 0 obj
<</Length 2665694>> stream