### PR TITLE
Adjust PDF::API2::Annotations documentation for border to actual.

### DIFF
--- a/lib/PDF/API2/Annotation.pm
+++ b/lib/PDF/API2/Annotation.pm
@@ -276,7 +276,7 @@ sub rect {
 
     $annotation = $annotation->border($h_radius, $v_radius, $width);
 
-Define the border style.  Defaults to 0, 0, 1.
+Define the border style.  Defaults to 0, 0, 0 (no border).
 
 =cut
 


### PR DESCRIPTION
The docs read that default is a (0,0,1) border, but it is in fact (and has been for a long time) a no-border (0,0,0).