### PR TITLE
Restore pageLabels compatibility.

### DIFF
--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -1728,7 +1728,11 @@ sub pageLabel {
             $options{'start'} = delete $options{'-start'};
         }
         if (exists $options{'-style'}) {
-            $options{'style'} = delete $options{'-style'};
+            my $style = delete $options{'-style'};
+            $options{'style'} = $style eq 'Roman' ? 'R' :
+                                $style eq 'roman' ? 'r' :
+                                $style eq 'Alpha' ? 'A' :
+                                $style eq 'alpha' ? 'a' : 'D';
         }
 
         # page_labels doesn't have a default numbering style, to be consistent


### PR DESCRIPTION
Before the last changes, `pageLabel` accepted style arguments `roman`, `arabic`, etc.
In 2.042, it merely takes the first letter (provided it is `a`, `d` or `r`). 
In short, `arabic` now comes out as __a__ (lowercase letters) instead of __D__ (Decimal arabic numerals).