### PR TITLE
Fix issue 75.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@
     - [GH-74] Fixed documentation error saying that stroke_color and fill_color
       can be chained.
 
+    - Crash instead of freezing if a PDF trailer's Prev keys result in a loop or
+      if multiple trailers use the same object ID and generation number.
+
 
 2.045     2023-09-25
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@
 
     - Fixed implementation of GH-77.
 
+    - Added $pdf->standard_fonts() and $pdf->is_standard_font($name) (initial
+      patch by Johan Vromans).
+
 
 2.046     2024-05-14
 

--- a/Changes
+++ b/Changes
@@ -6,6 +6,8 @@
     - Crash instead of freezing if a PDF trailer's Prev keys result in a loop or
       if multiple trailers use the same object ID and generation number.
 
+    - [GH-70] Fix off-by-one error when adding a page at the beginning of a PDF.
+
 
 2.045     2023-09-25
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    - Fixed implementation of GH-77.
+
+
 2.046     2024-05-14
 
     - [GH-74] Fixed documentation error saying that stroke_color and fill_color

--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@
 
     - [GH-70] Fix off-by-one error when adding a page at the beginning of a PDF.
 
+    - [GH-77] Significantly improve performance when adding many pages to a PDF.
+
 
 2.045     2023-09-25
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+2.046     2024-05-14
+
     - [GH-74] Fixed documentation error saying that stroke_color and fill_color
       can be chained.
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+2.047     2024-05-18
+
     - Fixed implementation of GH-77.
 
     - Added $pdf->standard_fonts() and $pdf->is_standard_font($name) (initial

--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ repository.type = git
 format = %-9v %{yyyy-MM-dd}d
 
 [Prereqs]
-perl = v5.10.0
+perl = v5.20.0
 Compress::Zlib = 1.0
 Font::TTF = 0
 

--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -2258,7 +2258,7 @@ a page's content:
 
 C<$file> may be either a file name, a filehandle, or a L<GD::Image> object.
 
-See L<PDF::API2::Content/"place"> for details about placing images on a page
+See L<PDF::API2::Content/"object"> for details about placing images on a page
 once they're imported.
 
 The image format is normally detected automatically based on the file's

--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -811,7 +811,7 @@ sub is_encrypted {
 
 =head2 outline
 
-    $outline = $pdf->outlines();
+    $outline = $pdf->outline();
 
 Creates (if needed) and returns the document's outline tree, which is also known
 as its bookmarks or the table of contents, depending on the PDF reader.

--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -2025,7 +2025,7 @@ sub font {
 
     $font = $pdf->synthetic_font($base_font, %options)
 
-Create and return a new synthetic font object.  See
+Creates and returns a new synthetic font object.  See
 L<PDF::API2::Resource::Font::SynFont> for details.
 
 =cut
@@ -2049,6 +2049,35 @@ sub synthetic_font {
     $obj->tounicodemap() if $opts{-unicodemap};
 
     return $obj;
+}
+
+=head2 standard_fonts
+
+    @names = $pdf->standard_fonts()
+
+Returns the names of the 14 standard (built-in) fonts.  See
+L<PDF::API2::Resource::Font::CoreFont> for details.
+
+=cut
+
+sub standard_fonts {
+    require PDF::API2::Resource::Font::CoreFont;
+    return PDF::API2::Resource::Font::CoreFont->names();
+}
+
+=head2 is_standard_font
+
+    $boolean = PDF::API2->is_standard_font($name);
+
+Returns true if C<$name> is an exact, case-sensitive match for one of the
+standard font names.
+
+=cut
+
+sub is_standard_font {
+    my $name = pop();
+    require PDF::API2::Resource::Font::CoreFont;
+    return PDF::API2::Resource::Font::CoreFont->is_standard($name);
 }
 
 =head2 font_path

--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -2836,7 +2836,7 @@ sub colorspace_devicen {
     $resource = $pdf->egstate();
 
 Creates and returns a new extended graphics state object, described in
-L<PDF::API2::ExtGState>.
+L<PDF::API2::Resource::ExtGState>.
 
 =cut
 

--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -1819,8 +1819,8 @@ sub default_page_size {
     }
 
     # Get
-    my $boundaries = $self->default_page_boundaries();
-    return @{$boundaries->{'media'}};
+    my %boundaries = $self->default_page_boundaries();
+    return @{$boundaries{'media'}};
 }
 
 =head2 default_page_boundaries

--- a/lib/PDF/API2/Basic/PDF/File.pm
+++ b/lib/PDF/API2/Basic/PDF/File.pm
@@ -1150,7 +1150,9 @@ sub locate_obj {
     my ($self, $num, $gen) = @_;
 
     my $tdict = $self;
+    my $seen = {};
     while (defined $tdict) {
+        $seen->{$tdict->{' loc'}} = 1;
         if (ref $tdict->{' xref'}{$num}) {
             my $ref = $tdict->{' xref'}{$num};
             return $ref unless scalar(@$ref) == 3;
@@ -1161,6 +1163,9 @@ sub locate_obj {
             }
         }
         $tdict = $tdict->{' prev'};
+        if ($seen->{$tdict->{' loc'}}) {
+            die 'Malformed PDF: trailer contains a loop or repeated object ID';
+        }
     }
     return;
 }

--- a/lib/PDF/API2/Basic/PDF/Pages.pm
+++ b/lib/PDF/API2/Basic/PDF/Pages.pm
@@ -132,15 +132,25 @@ sub add_page {
     my ($self, $page, $page_number) = @_;
     my $top = $self->get_top();
 
-    $page_number = -1 unless defined $page_number and $page_number <= $top->{'Count'}->val();
+    $page_number = -1 unless defined $page_number and $page_number < $top->{'Count'}->val();
 
     my $previous_page;
     if ($page_number == -1) {
-        $previous_page = $top->find_page($top->{'Count'}->val() - 1);
+        $previous_page = $top->{' last_page'};
+        unless (defined $previous_page) {
+            $previous_page = $top->find_page($top->{'Count'}->val() - 1);
+            $top->{' last_page'} = $page;
+        }
     }
     else {
         $page_number = $top->{'Count'}->val() + $page_number + 1 if $page_number < 0;
-        $previous_page = $top->find_page($page_number);
+        $page_number = 0 if $page_number < 0;
+        if ($top->{'Count'}->val() == scalar($top->{'Kids'}->realise->elements())) {
+            $previous_page = ($top->{'Kids'}->elements())[$page_number];
+        }
+        else {
+            $previous_page = $top->find_page($page_number);
+        }
     }
 
     my $parent;

--- a/lib/PDF/API2/Basic/PDF/Pages.pm
+++ b/lib/PDF/API2/Basic/PDF/Pages.pm
@@ -180,7 +180,7 @@ sub add_page_recurse {
 
     my $parent = $self;
     my $max_kids_per_parent = 8; # Why?
-    if (scalar $parent->{'Kids'}->elements() >= $max_kids_per_parent and $parent->{'Parent'} and $page_index < 1) {
+    if (scalar $parent->{'Kids'}->elements() >= $max_kids_per_parent and $parent->{'Parent'} and $page_index == -1) {
         my $grandparent = $parent->{'Parent'}->realise();
         $parent = $parent->new($parent->_pdf(), $grandparent);
 

--- a/lib/PDF/API2/Basic/PDF/Pages.pm
+++ b/lib/PDF/API2/Basic/PDF/Pages.pm
@@ -139,8 +139,8 @@ sub add_page {
         $previous_page = $top->{' last_page'};
         unless (defined $previous_page) {
             $previous_page = $top->find_page($top->{'Count'}->val() - 1);
-            $top->{' last_page'} = $page;
         }
+        $top->{' last_page'} = $page;
     }
     else {
         $page_number = $top->{'Count'}->val() + $page_number + 1 if $page_number < 0;

--- a/lib/PDF/API2/Resource/Font/CoreFont.pm
+++ b/lib/PDF/API2/Resource/Font/CoreFont.pm
@@ -8,9 +8,17 @@ use warnings;
 # VERSION
 
 use File::Basename;
-
+use List::Util qw(any);
 use PDF::API2::Util;
 use PDF::API2::Basic::PDF::Utils;
+
+my @standard_fonts = qw(
+    Courier Courier-Bold Courier-BoldOblique Courier-Oblique
+    Helvetica Helvetica-Bold Helvetica-BoldOblique Helvetica-Oblique
+    Symbol
+    Times-Bold Times-BoldItalic Times-Italic Times-Roman
+    ZapfDingbats
+);
 
 # Windows fonts with Type1 equivalents
 my $alias = {
@@ -188,7 +196,7 @@ sub new {
 
 =head2 is_standard
 
-    my $boolean = $class->is_standard($name);
+    my $boolean = PDF::API2::Resource::Font::CoreFont->is_standard($name);
 
 Returns true if C<$name> is an exact, case-sensitive match for one of the
 standard font names shown above.
@@ -197,22 +205,21 @@ standard font names shown above.
 
 sub is_standard {
     my $name = pop();
+    return any { $_ eq $name } @standard_fonts;
+}
 
-    return 1 if $name eq 'Courier';
-    return 1 if $name eq 'Courier-Bold';
-    return 1 if $name eq 'Courier-BoldOblique';
-    return 1 if $name eq 'Courier-Oblique';
-    return 1 if $name eq 'Helvetica';
-    return 1 if $name eq 'Helvetica-Bold';
-    return 1 if $name eq 'Helvetica-BoldOblique';
-    return 1 if $name eq 'Helvetica-Oblique';
-    return 1 if $name eq 'Symbol';
-    return 1 if $name eq 'Times-Bold';
-    return 1 if $name eq 'Times-BoldItalic';
-    return 1 if $name eq 'Times-Italic';
-    return 1 if $name eq 'Times-Roman';
-    return 1 if $name eq 'ZapfDingbats';
-    return;
+=head2 names
+
+    my @font_names = PDF::API2::Resource::Font::CoreFont->list();
+    my $array_ref  = PDF::API2::Resource::Font::CoreFont->list();
+
+Returns an array or a reference to an array containing the names of the built-in
+core (standard) fonts.
+
+=cut
+
+sub names {
+    return wantarray() ? @standard_fonts : [@standard_fonts];
 }
 
 1;

--- a/t/font-corefont.t
+++ b/t/font-corefont.t
@@ -19,4 +19,30 @@ foreach my $font (qw(bankgothic courier courierbold courierboldoblique
     lives_ok(sub { $pdf->corefont($font) }, "Load font $font");
 }
 
+ok($pdf->is_standard_font('Helvetica'),
+   q{Helvetica is a standard font});
+
+ok(!$pdf->is_standard_font('Comic Sans'),
+   q{Comic Sans is not a standard font});
+
+require PDF::API2::Resource::Font::CoreFont;
+my @names = PDF::API2::Resource::Font::CoreFont->names();
+is(scalar(@names), 14,
+   q{names() returns 14 elements in array context});
+
+my $arrayref = PDF::API2::Resource::Font::CoreFont->names();
+is(ref($arrayref), 'ARRAY',
+   q{names() returns an array reference in scalar context});
+is(scalar(@$arrayref), 14,
+   q{The array reference contains 14 elements});
+
+@names = $pdf->standard_fonts();
+is(scalar(@names), 14,
+   q{$pdf->standard_fonts() returns an array with 14 elements});
+
+foreach my $name (@names) {
+    ok(PDF::API2::Resource::Font::CoreFont->is_standard($name),
+       qq{$name is a core font});
+}
+
 done_testing();


### PR DESCRIPTION
`PDF::API2::default_page_size` calls `PDF::API2::default_page_boundaries`, which calls `PDF::API2::Page::boundaries`.

Without arguments, the latter returns a hash, but it is called in scalar context (apparently expecting a hash ref).

This fix changes the call to list (hash) context.