### PR TITLE
Support jumping to named external destination.

### DIFF
--- a/lib/PDF/API2/Annotation.pm
+++ b/lib/PDF/API2/Annotation.pm
@@ -158,11 +158,13 @@ sub launch {
 
 =head3 pdf
 
-    $annotation = $annotation->pdf($file, $page_number, $location, @args);
+    $annotation = $annotation->pdf($file, $dest, $location, @args);
 
-Open the PDF file located at C<$file> to the specified page number.
+Open the PDF file located at C<$file> to the specified destination.
 C<$location> and C<@args> are optional and set which part of the page should be
 displayed, as defined in L<PDF::API2::NamedDestination/"destination">.
+
+C<$dest> can be a page number, or a named destination prefixed with C<#>.
 
 =cut
 
@@ -173,7 +175,7 @@ sub pdf_file { return pdf(@_) }
 sub pdf {
     my $self = shift();
     my $file = shift();
-    my $page_number = shift();
+    my $dest = shift();
     my $location;
     my @args;
 
@@ -193,12 +195,17 @@ sub pdf {
     $self->{'A'}->{'F'} = PDFStr($file);
 
     unless (%options) {
-        my $destination = PDFNum($page_number);
-        $self->{'A'}->{'D'} = _destination($destination, $location, @args);
+	if ( $dest =~ /^#(.+)/ ) { # named dest
+	    $self->{'A'}->{'D'} = PDFStr($1);
+	}
+	else {
+	    my $destination = PDFNum($dest);
+	    $self->{'A'}->{'D'} = _destination($destination, $location, @args);
+	}
     }
     else {
         # Deprecated
-        $self->dest(PDFNum($page_number), %options);
+        $self->dest(PDFNum($dest), %options);
         $self->rect(@{$options{'-rect'}})     if defined $options{'-rect'};
         $self->border(@{$options{'-border'}}) if defined $options{'-border'};
     }


### PR DESCRIPTION
This is handled by method `pdf` in `Annotation.pm`.

I've chosen to pass the destination name in the second argument (fka `$page_number`), prefixed with a `#`. So

     $ann->pdf( "that.pdf", 42);                      # jumps to page 42
     $ann->pdf( "that.pdf", "#foo" );                 # jumps to named dest "foo"

The other alternative, appending the dest to the document name

     $ann->pdf( "that.pdf#foo" );

would open the possibility to pass both a named dest and a page number, which is no allowed.