### PR TITLE
Enhance ttfont to use an existing Font::TTF::Font object.

### DIFF
--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -1946,9 +1946,6 @@ extension.  If you're using a font with an atypical extension, you can set
 C<format> to one of C<truetype> (TrueType or OpenType), C<type1> (PostScript
 Type 1), or C<bitmap> (Adobe Bitmap).
 
-Setting format to C<truetype> is mandatory if the C<$name> argument is a
-C<Font::TTF::Font> object.
-
 =item * kerning
 
 Kerning (automatic adjustment of space between pairs of characters) is enabled
@@ -1993,6 +1990,7 @@ sub font {
     }
 
     my $format = $options{'format'};
+    $format //= 'truetype' if UNIVERSAL::isa($name, 'Font::TTF::Font');
     $format //= ($name =~ /\.[ot]tf$/i ? 'truetype' :
                  $name =~ /\.pf[ab]$/i ? 'type1'    :
                  $name =~ /\.bdf$/i    ? 'bitmap'   : '');

--- a/lib/PDF/API2.pm
+++ b/lib/PDF/API2.pm
@@ -1910,8 +1910,8 @@ Add a font to the PDF.  Returns the font object, to be used by
 L<PDF::API2::Content>.
 
 The font C<$name> is either the name of one of the L<standard 14
-fonts|PDF::API2::Resource::Font::CoreFont/"STANDARD FONTS"> (e.g. Helvetica) or
-the path to a font file.
+fonts|PDF::API2::Resource::Font::CoreFont/"STANDARD FONTS"> (e.g. Helvetica),
+a C<Font::TTF::Font> object, or the path to a font file.
 
     my $pdf = PDF::API2->new();
     my $font1 = $pdf->font('Helvetica-Bold');
@@ -1945,6 +1945,9 @@ The font format is normally detected automatically based on the file's
 extension.  If you're using a font with an atypical extension, you can set
 C<format> to one of C<truetype> (TrueType or OpenType), C<type1> (PostScript
 Type 1), or C<bitmap> (Adobe Bitmap).
+
+Setting format to C<truetype> is mandatory if the C<$name> argument is a
+C<Font::TTF::Font> object.
 
 =item * kerning
 
@@ -2193,7 +2196,7 @@ sub ttfont {
     }
     $opts{'embed'} //= 1;
 
-    my $file = _find_font($name) or croak "Unable to find font \"$name\"";
+    my $file = UNIVERSAL::isa($name,'Font::TTF::Font') ? $name : _find_font($name) or croak "Unable to find font \"$name\"";
     require PDF::API2::Resource::CIDFont::TrueType;
     my $obj = PDF::API2::Resource::CIDFont::TrueType->new($self->{'pdf'}, $file, %opts);
 

--- a/lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm
+++ b/lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm
@@ -359,9 +359,16 @@ sub readcffstructs {
 sub new {
     my ($class, $pdf, $file, %opts) = @_;
     my $data = {};
+    my $font;
 
-    confess "cannot find font '$file'" unless -f $file;
-    my $font = Font::TTF::Font->open($file);
+    # If the file is already a suitable font object, use it.
+    if ( UNIVERSAL::isa( $file, 'Font::TTF::Font' ) ) {
+	$font = $file;
+    }
+    else {
+	confess "cannot find font '$file'" unless -f $file;
+	$font = Font::TTF::Font->open($file);
+    }
     $data->{'obj'} = $font;
 
     $class = ref($class) if ref($class);


### PR DESCRIPTION
This simple patch enhances `font` to take an existing `Font::TTF::Font` object instead of a file name. This is useful in cases you aready have such an object, e.g. manually created, or derived from other sources.

The relevant code changes are in `lib/PDF/API2/Resource/CIDFont/TrueType/FontFile.pm`. The other changes are to propagate the functionality to the `ttfont` and `font` functions. And documentation.